### PR TITLE
Add required resolvers to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Setup
 
 Simply add the following to `<your_project>/project/plugins.sbt`:
 ```scala
+  resolvers += "bintray-spark-packages" at "https://dl.bintray.com/spark-packages/maven/"
+  
   addSbtPlugin("org.spark-packages" % "sbt-spark-package" % "0.2.3")
 ```
 


### PR DESCRIPTION
SBT wasn't able to download the plugin unless adding an additional resolver.
It would be great if the requirement is reflected in the documentation.