### PR TITLE
Instruction to add resolver for sbt-spark-package

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Setup
 
 Simply add the following to `<your_project>/project/plugins.sbt`:
 ```scala
+  resolvers += "bintray-spark-packages" at "https://dl.bintray.com/spark-packages/maven/"
+
   addSbtPlugin("org.spark-packages" % "sbt-spark-package" % "0.2.3")
 ```
 


### PR DESCRIPTION
Currently, resolver for generated spark packages is necessary to resolve `sbt-spark-pacakge` plugin.
see: https://github.com/databricks/sbt-spark-package/issues/9