### PR TITLE
do not provide structured streaming for kafka

### DIFF
--- a/src/main/scala/sbtsparkpackage/SparkPackagePlugin.scala
+++ b/src/main/scala/sbtsparkpackage/SparkPackagePlugin.scala
@@ -90,7 +90,7 @@ object SparkPackagePlugin extends AutoPlugin {
 
   // spark-streaming-kafka and spark-ganglia are not included in the spark-assembly, therefore it
   // should be okay to not mark those as provided.
-  val nonProvided = Seq("spark-streaming-", "spark-ganglia")
+  val nonProvided = Seq("spark-streaming-", "spark-ganglia", "spark-sql-kafka")
 
   val validatePackaging = Def.task {
     // Make sure Spark configuration is "provided"


### PR DESCRIPTION
Following the guide at:
https://spark.apache.org/docs/latest/structured-streaming-kafka-integration.html

When I add the spark-sql-kafka-0-10 as a component, it gets
automatically provided.

When I add the package as a depdendency, I get the error that "Please
add any Spark dependencies by supplying the sparkVersion and
sparkComponents."